### PR TITLE
fix remote sample node settings and webview app manifest

### DIFF
--- a/misc/remote-sample-node-settings.yml
+++ b/misc/remote-sample-node-settings.yml
@@ -1,6 +1,6 @@
 general:
   bootstrapNodes:
-    - /dns4/demo-bootstrap.actyx.net/tcp/4001/ipfs/QmUD1mA3Y8qSQB34HmgSNcxDss72UHW2kzQy7RdVstN2hH
+    - /ip4/3.125.108.42/tcp/4001/ipfs/QmUD1mA3Y8qSQB34HmgSNcxDss72UHW2kzQy7RdVstN2hH
   displayName: Remote Sample Node
   swarmKey: L2tleS9zd2FybS9wc2svMS4wLjAvCi9iYXNlMTYvCmQ3YjBmNDFjY2ZlYTEyM2FkYTJhYWI0MmY2NjRjOWUyNWUwZWYyZThmNGJjNjJlOTg3NmE3NDU1MTc3ZWQzOGIK
 licensing:

--- a/sample-webview-app/ax-manifest.yml
+++ b/sample-webview-app/ax-manifest.yml
@@ -7,4 +7,4 @@ description: "A sample webview app"
 icon: ./assets/icon.png
 dist: ./dist/
 main: index.html
-settingsSchema: ./settings-schema.json
+settingsSchema: ./settings.schema.json


### PR DESCRIPTION
The bootstrap node address did not work on my tablet, I had to exchange it with `/ip4/3.125.108.42/tcp/4001/ipfs/QmUD1mA3Y8qSQB34HmgSNcxDss72UHW2kzQy7RdVstN2hH` . This address did not work on my laptop and ActyxOS on Android though, that's why I only changed it for the remote sample node settings.