### PR TITLE
Allow sample-docker-app to be built for arm

### DIFF
--- a/sample-docker-app/Dockerfile
+++ b/sample-docker-app/Dockerfile
@@ -2,7 +2,9 @@ FROM node:10-alpine
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-RUN npm install
-COPY . .
+RUN apk add -t install-deps build-base python
+RUN npm install --only=prod
+RUN apk del install-deps
+COPY ./*.js .
 
 CMD ["node", "index.js"]

--- a/sample-docker-app/package.json
+++ b/sample-docker-app/package.json
@@ -11,7 +11,8 @@
     "build": "tsc",
     "start": "ts-node index",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build:image": "npm run build && docker build -t sample-docker-app ."
+    "build:image": "npm run build && docker build -t sample-docker-app .",
+    "build:image-aarch64": "npm run build && docker run --privileged -e IMAGE_TAG=\"sample-docker-app:arm\" -e PLATFORM=\"linux/arm64\" --rm -v $(pwd):/data actyx/windows-cross-builder && docker load -i sample-docker-app:arm.tar.gz"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
The pond has native dependencies that need some tools in order to be built for arm, test it out with `docker run --privileged -e IMAGE_TAG="quickstart:latest" -e PLATFORM="linux/arm64" --rm -v $(pwd):/data actyx/windows-cross-builder`