### PR TITLE
Fix webview manifest to package correct index.html

### DIFF
--- a/sample-webview-app/ax-manifest.yml
+++ b/sample-webview-app/ax-manifest.yml
@@ -6,5 +6,5 @@ displayName: Sample Webview App
 description: "A sample webview app"
 icon: ./assets/icon.png
 dist: ./dist/
-main: index.html
+main: ./dist/index.html
 settingsSchema: ./settings.schema.json


### PR DESCRIPTION
The packaged WebView app does not work because we are packaging the wrong index.html file. This PR fixes this.